### PR TITLE
Fix TODO modal display in production environment

### DIFF
--- a/src/presentation/dialogs/backup_manager_dialog.py
+++ b/src/presentation/dialogs/backup_manager_dialog.py
@@ -88,6 +88,7 @@ class BackupManagerDialog(QDialog):
     def _create_backup_tab(self) -> QWidget:
         """백업 관리 탭 생성 (수평 분할: 백업 목록 + TODO 미리보기)"""
         widget = QWidget()
+        widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         main_layout = QVBoxLayout(widget)
         main_layout.setContentsMargins(*config.LAYOUT_MARGINS['backup_dialog_tab'])
         main_layout.setSpacing(config.LAYOUT_SPACING['backup_dialog_tab'])
@@ -98,6 +99,7 @@ class BackupManagerDialog(QDialog):
 
         # === 왼쪽: 백업 파일 목록 ===
         left_widget = QWidget()
+        left_widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         left_layout = QVBoxLayout(left_widget)
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_layout.setSpacing(8)
@@ -148,6 +150,7 @@ class BackupManagerDialog(QDialog):
 
         # === 오른쪽: TODO 미리보기 ===
         right_widget = QWidget()
+        right_widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         right_layout = QVBoxLayout(right_widget)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(config.BACKUP_DIALOG_LAYOUT['checkbox_spacing'])
@@ -191,6 +194,7 @@ class BackupManagerDialog(QDialog):
     def _create_completed_tab(self) -> QWidget:
         """완료 정리 탭 생성"""
         widget = QWidget()
+        widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         layout = QVBoxLayout(widget)
         layout.setContentsMargins(*config.LAYOUT_MARGINS['backup_dialog_tab'])
         layout.setSpacing(config.LAYOUT_SPACING['backup_dialog_tab'])
@@ -221,6 +225,7 @@ class BackupManagerDialog(QDialog):
     def _create_select_tab(self) -> QWidget:
         """선택 삭제 탭 생성"""
         widget = QWidget()
+        widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         layout = QVBoxLayout(widget)
         layout.setContentsMargins(*config.LAYOUT_MARGINS['backup_dialog_tab'])
         layout.setSpacing(config.LAYOUT_SPACING['backup_dialog_tab'])
@@ -254,6 +259,7 @@ class BackupManagerDialog(QDialog):
         scroll.setObjectName("todoScroll")
 
         self.checkbox_widget = QWidget()
+        self.checkbox_widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         self.checkbox_layout = QVBoxLayout(self.checkbox_widget)
         self.checkbox_layout.setContentsMargins(*config.BACKUP_DIALOG_LAYOUT['checkbox_margins'])
         self.checkbox_layout.setSpacing(config.BACKUP_DIALOG_LAYOUT['checkbox_spacing'])

--- a/src/presentation/dialogs/edit_dialog.py
+++ b/src/presentation/dialogs/edit_dialog.py
@@ -134,6 +134,7 @@ class EditDialog(QDialog):
 
         # 콘텐츠 컨테이너
         content_widget = QWidget()
+        content_widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
         content_layout = QVBoxLayout(content_widget)
         content_layout.setContentsMargins(24, 24, 24, 24)
         content_layout.setSpacing(16)
@@ -1067,6 +1068,9 @@ class SubTaskEditDialog(QDialog):
 
     def _setup_ui(self):
         """UI 구성"""
+        # 다이얼로그 배경 렌더링을 위한 속성 설정
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)

--- a/src/presentation/widgets/rich_text_widget.py
+++ b/src/presentation/widgets/rich_text_widget.py
@@ -6,7 +6,7 @@
 - 실행 파일 보안 검증
 """
 
-from PyQt6.QtWidgets import QLabel, QMessageBox
+from PyQt6.QtWidgets import QLabel, QMessageBox, QSizePolicy
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QCursor
 import webbrowser
@@ -44,6 +44,10 @@ class RichTextWidget(QLabel):
         # 1줄 고정 높이 및 줄바꿈 비활성화
         self.setFixedHeight(config.WIDGET_SIZES['todo_text_line_height'])
         self.setWordWrap(False)
+
+        # Size Policy 설정: 너비는 레이아웃에 맡기고(Ignored), 높이는 고정(Fixed)
+        # 이렇게 하면 텍스트 길이에 상관없이 레이아웃에서 지정한 너비를 사용
+        self.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
 
         # 링크 클릭 시그널 연결
         self.linkActivated.connect(self._on_link_activated)


### PR DESCRIPTION
사용자 환경에서 발생하는 두 가지 UI 문제 해결:

1. 다이얼로그 배경 White 표시 문제
   - EditDialog content_widget에 WA_StyledBackground 속성 추가
   - SubTaskEditDialog에 WA_StyledBackground 속성 추가
   - BackupManagerDialog의 모든 위젯에 WA_StyledBackground 속성 추가
   - PyQt6에서 QWidget은 WA_StyledBackground 속성이 없으면 시스템 기본 배경을 사용하여 환경에 따라 White로 표시됨

2. 하위 할일 펼치기 시 UI 오른쪽 밀림 문제
   - RichTextWidget에 size policy 설정 추가
   - QLabel 기본 동작이 텍스트 길이에 따라 sizeHint를 반환하여 긴 텍스트 시 레이아웃이 밀리는 문제 해결
   - setSizePolicy(Ignored, Fixed)로 너비는 레이아웃에 맡김

이 두 문제는 Qt의 기본 동작과 환경 차이로 인해 발생하며,
명시적 속성 설정으로 모든 환경에서 일관된 동작 보장